### PR TITLE
basic boolean conversion and interpretation behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,80 @@
 # MuchBoolean
 
-An API for friendly boolean parsing and handling
+An API for friendly boolean conversion, interpretation and handling
 
 ## Usage
 
-TODO: Write code samples and usage instructions here
+```ruby
+require 'much-boolean'
+MuchBoolean::FALSE_VALUES # => [ nil, 0, "0",
+                          #      false, "false", "False", "FALSE", "f", "F",
+                          #      "no", "No", "NO", "n", "N"
+                          #    ]
+
+# nil, zero/one type values
+MuchBoolean.convert(nil) # => false
+MuchBoolean.convert(0)   # => false
+MuchBoolean.convert('0') # => false
+MuchBoolean.convert(1)   # => true
+MuchBoolean.convert('1') # => true
+
+# true/false type values
+MuchBoolean.convert(false)   # => false
+MuchBoolean.convert("false") # => false
+MuchBoolean.convert("False") # => false
+MuchBoolean.convert("FALSE") # => false
+MuchBoolean.convert("f")     # => false
+MuchBoolean.convert("F")     # => false
+MuchBoolean.convert(true)    # => true
+MuchBoolean.convert("true")  # => true
+MuchBoolean.convert("True")  # => true
+MuchBoolean.convert("TRUE")  # => true
+MuchBoolean.convert("t")     # => true
+MuchBoolean.convert("T")     # => true
+
+# yes/no type values
+MuchBoolean.convert("no")  # => false
+MuchBoolean.convert("No")  # => false
+MuchBoolean.convert("NO")  # => false
+MuchBoolean.convert("n")   # => false
+MuchBoolean.convert("N")   # => false
+MuchBoolean.convert("yes") # => true
+MuchBoolean.convert("Yes") # => true
+MuchBoolean.convert("YES") # => true
+MuchBoolean.convert("y")   # => true
+MuchBoolean.convert("Y")   # => true
+
+# all other values always interpreted as `true`
+MuchBoolean.convert('some-string') # => true
+MuchBoolean.convert('1938')        # => true
+MuchBoolean.convert('1938.5')      # => true
+MuchBoolean.convert(Date.today)    # => true
+MuchBoolean.convert(Time.now)      # => true
+
+
+
+# create instances to track given values and the actually boolean values they map to
+
+bool = MuchBoolean.new
+bool.given  # => nil
+bool.actual # => false
+
+MuchBoolean::FALSE_VALUES.each do |val|
+  bool = MuchBoolean.new(val)
+  bool.given    # => {val}
+  bool.actual   # => false
+  bool == false # => true
+  bool == true  # => false
+end
+
+['some-string', '1938', '1938.5', Date.today, Time.now].each do |val|
+  bool = MuchBoolean.new(val)
+  bool.given    # => {val}
+  bool.actual   # => true
+  bool == true  # => true
+  bool == false # => false
+end
+```
 
 ## Installation
 

--- a/lib/much-boolean.rb
+++ b/lib/much-boolean.rb
@@ -1,4 +1,31 @@
 require "much-boolean/version"
 
-module MuchBoolean
+class MuchBoolean
+
+  FALSE_VALUES = [
+    nil,
+    0, '0',
+    false, 'false', 'False', 'FALSE', 'f', 'F',
+    'no', 'No', 'NO', 'n', 'N'
+  ].freeze
+
+  def self.convert(value)
+    !FALSE_VALUES.include?(value)
+  end
+
+  attr_reader :given, :actual
+
+  def initialize(given = nil)
+    @given  = given
+    @actual = self.class.convert(@given)
+  end
+
+  def ==(other_boolean)
+    if other_boolean.kind_of?(MuchBoolean)
+      self.actual == other_boolean.actual
+    else
+      self.actual == other_boolean
+    end
+  end
+
 end

--- a/lib/much-boolean/version.rb
+++ b/lib/much-boolean/version.rb
@@ -1,3 +1,3 @@
-module MuchBoolean
+class MuchBoolean
   VERSION = "0.0.1"
 end

--- a/much-boolean.gemspec
+++ b/much-boolean.gemspec
@@ -8,8 +8,8 @@ Gem::Specification.new do |gem|
   gem.version     = MuchBoolean::VERSION
   gem.authors     = ["Kelly Redding", "Collin Redding"]
   gem.email       = ["kelly@kellyredding.com", "collin.redding@me.com "]
-  gem.summary     = "An API for friendly boolean parsing and handling"
-  gem.description = "An API for friendly boolean parsing and handling"
+  gem.summary     = "An API for friendly boolean conversion, interpretation and handling"
+  gem.description = "An API for friendly boolean conversion, interpretation and handling"
   gem.homepage    = "https://github.com/redding/much-boolean"
   gem.license     = 'MIT'
 

--- a/test/unit/much-boolean_tests.rb
+++ b/test/unit/much-boolean_tests.rb
@@ -1,0 +1,108 @@
+require 'assert'
+require 'much-boolean'
+
+class MuchBoolean
+
+  class UnitTests < Assert::Context
+    desc "MuchBoolean"
+    subject{ MuchBoolean }
+
+    should have_imeth :convert
+
+    should "know its false values" do
+      exp = [
+        nil,
+        0, '0',
+        false, 'false', 'False', 'FALSE', 'f', 'F',
+        'no', 'No', 'NO', 'n', 'N'
+      ]
+      assert_equal exp, subject::FALSE_VALUES
+    end
+
+    should "convert nil values as `false`" do
+      assert_false MuchBoolean.convert(nil)
+    end
+
+    should "convert 'zero-ish' values as `false`" do
+      [0, '0'].each do |val|
+        assert_false MuchBoolean.convert(val)
+      end
+    end
+
+    should "convert 'false-ish' values as `false`" do
+      [false, 'false', 'False', 'FALSE', 'f', 'F'].each do |val|
+        assert_false MuchBoolean.convert(val)
+      end
+    end
+
+    should "convert 'no-ish' values as `false`" do
+      ['no', 'No', 'NO', 'n', 'N'].each do |val|
+        assert_false MuchBoolean.convert(val)
+      end
+    end
+
+    should "convert 'one-ish' values as `true`" do
+      [1, '1'].each do |val|
+        assert_true MuchBoolean.convert(val)
+      end
+    end
+
+    should "convert 'true-ish' values as `true`" do
+      [true, 'true', 'True', 'TRUE', 't', 'T'].each do |val|
+        assert_true MuchBoolean.convert(val)
+      end
+    end
+
+    should "convert 'yes-ish' values as `true`" do
+      ['yes', 'Yes', 'YES', 'y', 'Y'].each do |val|
+        assert_true MuchBoolean.convert(val)
+      end
+    end
+
+    should "convert all other values as `true`" do
+      [Factory.string, Factory.integer, Factory.date, Factory.time].each do |val|
+        assert_true MuchBoolean.convert(val)
+      end
+    end
+
+  end
+
+  class InitTests < UnitTests
+    desc "when init"
+    setup do
+      @actual = Factory.boolean
+      @bool = MuchBoolean.new(@actual)
+    end
+    subject{ @bool }
+
+    should have_reader :given, :actual
+
+    should "know its given and actual boolean values" do
+      assert_equal @actual, subject.given
+      assert_equal @actual, subject.actual
+
+      str  = Factory.string
+      bool = MuchBoolean.new(str)
+      assert_equal str, bool.given
+      assert_true  bool.actual
+    end
+
+    should "default its actual value to `false` when given nothing" do
+      bool = MuchBoolean.new
+      assert_nil   bool.given
+      assert_false bool.actual
+    end
+
+    should "know if it is equal to another much boolean or not" do
+      equal_bool = MuchBoolean.new(@actual)
+      not_bool   = MuchBoolean.new(!@actual)
+
+      assert_equal     equal_bool, subject
+      assert_not_equal not_bool,   subject
+      assert_equal     subject,    @actual
+      assert_not_equal subject,    !@actual
+    end
+
+  end
+
+end


### PR DESCRIPTION
The idea here is to interpret incoming values as booleans in a friendly,
flexible way and be able to easily compare them to other booleans (both
`MuchBoolean` and `TrueClass` and `FalseClass`).  Use `convert` to just
convert a given value to an actual boolean value using much-boolean's
"friendly" interpretation logic.  Create instances using `new` to track
a given values interpreted boolean value and use as a boolean in
comparisons, etc.

Note: this was extracted from the ns-options gem with a few differences:
- no `actual=` writer (this was only needed b/c of ns-options behavior)
- no `returned_value` method (this was only needed b/c of ns-options
  behavior)
- support for "yes/no" type values
- support for additional "true/false" type values
- exposed the underlying conversion logic in a `convert` singleton so
  you don't _have_ to build an instance and get its `actual` value
  if all you care about is the actual boolean value

@jcredding ready for review.  Are you cool with the departures I did from ns-options' version?
