### PR TITLE
add in methods to convert boolean values back to human-friendly values

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ MuchBoolean::FALSE_VALUES # => [ nil, 0, "0",
                           #      "no", "No", "NO", "n", "N"
                           #    ]
 
+# convert human-friendly representative values to actual booleans
+
 # nil, zero/one type values
 MuchBoolean.convert(nil) # => false
 MuchBoolean.convert(0)   # => false
@@ -53,7 +55,38 @@ MuchBoolean.convert(Time.now)      # => true
 
 
 
-# create instances to track given values and the actually boolean values they map to
+# convert actual booleans back to human-friendly representative values
+
+MuchBoolean.one_zero(true)       # => 1
+MuchBoolean.one_zero(false)      # => 0
+MuchBoolean.one_zero(true).to_s  # => '1'
+MuchBoolean.one_zero(false).to_s # => '0'
+
+MuchBoolean.true_false(true)  # => 'true'
+MuchBoolean.true_false(false) # => 'false'
+MuchBoolean.True_False(true)  # => 'True'
+MuchBoolean.True_False(false) # => 'False'
+MuchBoolean.TRUE_FALSE(true)  # => 'TRUE'
+MuchBoolean.TRUE_FALSE(false) # => 'FALSE'
+MuchBoolean.t_f(true)         # => 't'
+MuchBoolean.t_f(false)        # => 'f'
+MuchBoolean.T_F(true)         # => 'T'
+MuchBoolean.T_F(false)        # => 'F'
+
+MuchBoolean.yes_no(true)  # => 'yes'
+MuchBoolean.yes_no(false) # => 'no'
+MuchBoolean.Yes_No(true)  # => 'Yes'
+MuchBoolean.Yes_No(false) # => 'No'
+MuchBoolean.YES_NO(true)  # => 'YES'
+MuchBoolean.YES_NO(false) # => 'NO'
+MuchBoolean.y_n(true)     # => 'y'
+MuchBoolean.y_n(false)    # => 'n'
+MuchBoolean.Y_N(true)     # => 'Y'
+MuchBoolean.Y_N(false)    # => 'N'
+
+
+
+# create instances to track given human-friendly values and the boolean values they map to
 
 bool = MuchBoolean.new
 bool.given  # => nil

--- a/lib/much-boolean.rb
+++ b/lib/much-boolean.rb
@@ -13,6 +13,50 @@ class MuchBoolean
     !FALSE_VALUES.include?(value)
   end
 
+  def self.one_zero(boolean)
+    boolean ? 1 : 0
+  end
+
+  def self.true_false(boolean)
+    boolean ? 'true' : 'false'
+  end
+
+  def self.True_False(boolean)
+    boolean ? 'True' : 'False'
+  end
+
+  def self.TRUE_FALSE(boolean)
+    boolean ? 'TRUE' : 'FALSE'
+  end
+
+  def self.t_f(boolean)
+    boolean ? 't' : 'f'
+  end
+
+  def self.T_F(boolean)
+    boolean ? 'T' : 'F'
+  end
+
+  def self.yes_no(boolean)
+    boolean ? 'yes' : 'no'
+  end
+
+  def self.Yes_No(boolean)
+    boolean ? 'Yes' : 'No'
+  end
+
+  def self.YES_NO(boolean)
+    boolean ? 'YES' : 'NO'
+  end
+
+  def self.y_n(boolean)
+    boolean ? 'y' : 'n'
+  end
+
+  def self.Y_N(boolean)
+    boolean ? 'Y' : 'N'
+  end
+
   attr_reader :given, :actual
 
   def initialize(given = nil)

--- a/test/unit/much-boolean_tests.rb
+++ b/test/unit/much-boolean_tests.rb
@@ -7,7 +7,10 @@ class MuchBoolean
     desc "MuchBoolean"
     subject{ MuchBoolean }
 
-    should have_imeth :convert
+    should have_imeths :convert
+    should have_imeths :one_zero
+    should have_imeths :true_false, :True_False, :TRUE_FALSE, :t_f, :T_F
+    should have_imeths :yes_no,  :Yes_No, :YES_NO, :y_n, :Y_N
 
     should "know its false values" do
       exp = [
@@ -63,6 +66,62 @@ class MuchBoolean
       [Factory.string, Factory.integer, Factory.date, Factory.time].each do |val|
         assert_true MuchBoolean.convert(val)
       end
+    end
+
+    should "encode booleans as ones and zeros" do
+      assert_equal 1, MuchBoolean.one_zero(true)
+      assert_equal 0, MuchBoolean.one_zero(false)
+
+      assert_true  MuchBoolean.convert(MuchBoolean.one_zero(true))
+      assert_false MuchBoolean.convert(MuchBoolean.one_zero(false))
+    end
+
+    should "encode booleans as true/false strings" do
+      assert_equal 'true',  MuchBoolean.true_false(true)
+      assert_equal 'false', MuchBoolean.true_false(false)
+      assert_equal 'True',  MuchBoolean.True_False(true)
+      assert_equal 'False', MuchBoolean.True_False(false)
+      assert_equal 'TRUE',  MuchBoolean.TRUE_FALSE(true)
+      assert_equal 'FALSE', MuchBoolean.TRUE_FALSE(false)
+      assert_equal 't',     MuchBoolean.t_f(true)
+      assert_equal 'f',     MuchBoolean.t_f(false)
+      assert_equal 'T',     MuchBoolean.T_F(true)
+      assert_equal 'F',     MuchBoolean.T_F(false)
+
+      assert_true  MuchBoolean.convert(MuchBoolean.true_false(true))
+      assert_false MuchBoolean.convert(MuchBoolean.true_false(false))
+      assert_true  MuchBoolean.convert(MuchBoolean.True_False(true))
+      assert_false MuchBoolean.convert(MuchBoolean.True_False(false))
+      assert_true  MuchBoolean.convert(MuchBoolean.TRUE_FALSE(true))
+      assert_false MuchBoolean.convert(MuchBoolean.TRUE_FALSE(false))
+      assert_true  MuchBoolean.convert(MuchBoolean.t_f(true))
+      assert_false MuchBoolean.convert(MuchBoolean.t_f(false))
+      assert_true  MuchBoolean.convert(MuchBoolean.T_F(true))
+      assert_false MuchBoolean.convert(MuchBoolean.T_F(false))
+    end
+
+    should "encode booleans as yes/no strings" do
+      assert_equal 'yes', MuchBoolean.yes_no(true)
+      assert_equal 'no',  MuchBoolean.yes_no(false)
+      assert_equal 'Yes', MuchBoolean.Yes_No(true)
+      assert_equal 'No',  MuchBoolean.Yes_No(false)
+      assert_equal 'YES', MuchBoolean.YES_NO(true)
+      assert_equal 'NO',  MuchBoolean.YES_NO(false)
+      assert_equal 'y',   MuchBoolean.y_n(true)
+      assert_equal 'n',   MuchBoolean.y_n(false)
+      assert_equal 'Y',   MuchBoolean.Y_N(true)
+      assert_equal 'N',   MuchBoolean.Y_N(false)
+
+      assert_true  MuchBoolean.convert(MuchBoolean.yes_no(true))
+      assert_false MuchBoolean.convert(MuchBoolean.yes_no(false))
+      assert_true  MuchBoolean.convert(MuchBoolean.Yes_No(true))
+      assert_false MuchBoolean.convert(MuchBoolean.Yes_No(false))
+      assert_true  MuchBoolean.convert(MuchBoolean.YES_NO(true))
+      assert_false MuchBoolean.convert(MuchBoolean.YES_NO(false))
+      assert_true  MuchBoolean.convert(MuchBoolean.y_n(true))
+      assert_false MuchBoolean.convert(MuchBoolean.y_n(false))
+      assert_true  MuchBoolean.convert(MuchBoolean.Y_N(true))
+      assert_false MuchBoolean.convert(MuchBoolean.Y_N(false))
     end
 
   end


### PR DESCRIPTION
This is the opposite of the `convert` method, provided in a variety
of formats based on the `FALSE_VALUES` that `convert` supports.  The
tests try to illustrate that converting a human-friendly value generated
with this API results in the boolean used to generate the human-friendly
value.

The goal here is to provide an complimentary API to `convert` for
generating human friendly values `convert` can process.

@jcredding ready for review.
