### PR TITLE
switch to ignoring nil values both when converting and deconverting

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,15 +6,17 @@ An API for friendly boolean conversion, interpretation and handling
 
 ```ruby
 require 'much-boolean'
-MuchBoolean::FALSE_VALUES # => [ nil, 0, "0",
+MuchBoolean::FALSE_VALUES # => [ 0, "0",
                           #      false, "false", "False", "FALSE", "f", "F",
                           #      "no", "No", "NO", "n", "N"
                           #    ]
 
 # convert human-friendly representative values to actual booleans
 
-# nil, zero/one type values
-MuchBoolean.convert(nil) # => false
+# nil values - theses are ignored
+MuchBoolean.convert(nil) # => nil
+
+# zero/one type values
 MuchBoolean.convert(0)   # => false
 MuchBoolean.convert('0') # => false
 MuchBoolean.convert(1)   # => true
@@ -90,7 +92,7 @@ MuchBoolean.Y_N(false)    # => 'N'
 
 bool = MuchBoolean.new
 bool.given  # => nil
-bool.actual # => false
+bool.actual # => nil
 
 MuchBoolean::FALSE_VALUES.each do |val|
   bool = MuchBoolean.new(val)

--- a/lib/much-boolean.rb
+++ b/lib/much-boolean.rb
@@ -3,59 +3,27 @@ require "much-boolean/version"
 class MuchBoolean
 
   FALSE_VALUES = [
-    nil,
     0, '0',
     false, 'false', 'False', 'FALSE', 'f', 'F',
     'no', 'No', 'NO', 'n', 'N'
   ].freeze
 
   def self.convert(value)
+    return nil if value.nil?
     !FALSE_VALUES.include?(value)
   end
 
-  def self.one_zero(boolean)
-    boolean ? 1 : 0
-  end
-
-  def self.true_false(boolean)
-    boolean ? 'true' : 'false'
-  end
-
-  def self.True_False(boolean)
-    boolean ? 'True' : 'False'
-  end
-
-  def self.TRUE_FALSE(boolean)
-    boolean ? 'TRUE' : 'FALSE'
-  end
-
-  def self.t_f(boolean)
-    boolean ? 't' : 'f'
-  end
-
-  def self.T_F(boolean)
-    boolean ? 'T' : 'F'
-  end
-
-  def self.yes_no(boolean)
-    boolean ? 'yes' : 'no'
-  end
-
-  def self.Yes_No(boolean)
-    boolean ? 'Yes' : 'No'
-  end
-
-  def self.YES_NO(boolean)
-    boolean ? 'YES' : 'NO'
-  end
-
-  def self.y_n(boolean)
-    boolean ? 'y' : 'n'
-  end
-
-  def self.Y_N(boolean)
-    boolean ? 'Y' : 'N'
-  end
+  def self.one_zero(boolean);   Mapping.new(boolean, 1,      0);       end
+  def self.true_false(boolean); Mapping.new(boolean, 'true', 'false'); end
+  def self.True_False(boolean); Mapping.new(boolean, 'True', 'False'); end
+  def self.TRUE_FALSE(boolean); Mapping.new(boolean, 'TRUE', 'FALSE'); end
+  def self.t_f(boolean);        Mapping.new(boolean, 't',    'f');     end
+  def self.T_F(boolean);        Mapping.new(boolean, 'T',    'F');     end
+  def self.yes_no(boolean);     Mapping.new(boolean, 'yes',  'no');    end
+  def self.Yes_No(boolean);     Mapping.new(boolean, 'Yes',  'No');    end
+  def self.YES_NO(boolean);     Mapping.new(boolean, 'YES',  'NO');    end
+  def self.y_n(boolean);        Mapping.new(boolean, 'y',    'n');     end
+  def self.Y_N(boolean);        Mapping.new(boolean, 'Y',    'N');     end
 
   attr_reader :given, :actual
 
@@ -69,6 +37,14 @@ class MuchBoolean
       self.actual == other_boolean.actual
     else
       self.actual == other_boolean
+    end
+  end
+
+  module Mapping
+    def self.new(boolean_value, true_value, false_value)
+      return nil         if boolean_value.nil?
+      return false_value if boolean_value == false
+      true_value
     end
   end
 

--- a/test/unit/much-boolean_tests.rb
+++ b/test/unit/much-boolean_tests.rb
@@ -14,7 +14,6 @@ class MuchBoolean
 
     should "know its false values" do
       exp = [
-        nil,
         0, '0',
         false, 'false', 'False', 'FALSE', 'f', 'F',
         'no', 'No', 'NO', 'n', 'N'
@@ -22,8 +21,8 @@ class MuchBoolean
       assert_equal exp, subject::FALSE_VALUES
     end
 
-    should "convert nil values as `false`" do
-      assert_false MuchBoolean.convert(nil)
+    should "ignore nil values when converting" do
+      assert_nil MuchBoolean.convert(nil)
     end
 
     should "convert 'zero-ish' values as `false`" do
@@ -69,8 +68,10 @@ class MuchBoolean
     end
 
     should "encode booleans as ones and zeros" do
-      assert_equal 1, MuchBoolean.one_zero(true)
-      assert_equal 0, MuchBoolean.one_zero(false)
+      assert_equal 1,   MuchBoolean.one_zero(true)
+      assert_equal 0,   MuchBoolean.one_zero(false)
+      assert_equal nil, MuchBoolean.one_zero(nil)
+      assert_equal 1,   MuchBoolean.one_zero(Factory.string)
 
       assert_true  MuchBoolean.convert(MuchBoolean.one_zero(true))
       assert_false MuchBoolean.convert(MuchBoolean.one_zero(false))
@@ -79,14 +80,24 @@ class MuchBoolean
     should "encode booleans as true/false strings" do
       assert_equal 'true',  MuchBoolean.true_false(true)
       assert_equal 'false', MuchBoolean.true_false(false)
+      assert_equal nil,     MuchBoolean.true_false(nil)
+      assert_equal 'true',  MuchBoolean.true_false(Factory.string)
       assert_equal 'True',  MuchBoolean.True_False(true)
       assert_equal 'False', MuchBoolean.True_False(false)
+      assert_equal nil,     MuchBoolean.True_False(nil)
+      assert_equal 'True',  MuchBoolean.True_False(Factory.string)
       assert_equal 'TRUE',  MuchBoolean.TRUE_FALSE(true)
       assert_equal 'FALSE', MuchBoolean.TRUE_FALSE(false)
+      assert_equal nil,     MuchBoolean.TRUE_FALSE(nil)
+      assert_equal 'TRUE',  MuchBoolean.TRUE_FALSE(Factory.string)
       assert_equal 't',     MuchBoolean.t_f(true)
       assert_equal 'f',     MuchBoolean.t_f(false)
+      assert_equal nil,     MuchBoolean.t_f(nil)
+      assert_equal 't',     MuchBoolean.t_f(Factory.string)
       assert_equal 'T',     MuchBoolean.T_F(true)
       assert_equal 'F',     MuchBoolean.T_F(false)
+      assert_equal nil,     MuchBoolean.T_F(nil)
+      assert_equal 'T',     MuchBoolean.T_F(Factory.string)
 
       assert_true  MuchBoolean.convert(MuchBoolean.true_false(true))
       assert_false MuchBoolean.convert(MuchBoolean.true_false(false))
@@ -103,14 +114,24 @@ class MuchBoolean
     should "encode booleans as yes/no strings" do
       assert_equal 'yes', MuchBoolean.yes_no(true)
       assert_equal 'no',  MuchBoolean.yes_no(false)
+      assert_equal nil,   MuchBoolean.yes_no(nil)
+      assert_equal 'yes', MuchBoolean.yes_no(Factory.string)
       assert_equal 'Yes', MuchBoolean.Yes_No(true)
       assert_equal 'No',  MuchBoolean.Yes_No(false)
+      assert_equal nil,   MuchBoolean.Yes_No(nil)
+      assert_equal 'Yes', MuchBoolean.Yes_No(Factory.string)
       assert_equal 'YES', MuchBoolean.YES_NO(true)
       assert_equal 'NO',  MuchBoolean.YES_NO(false)
+      assert_equal nil,   MuchBoolean.YES_NO(nil)
+      assert_equal 'YES', MuchBoolean.YES_NO(Factory.string)
       assert_equal 'y',   MuchBoolean.y_n(true)
       assert_equal 'n',   MuchBoolean.y_n(false)
+      assert_equal nil,   MuchBoolean.y_n(nil)
+      assert_equal 'y',   MuchBoolean.y_n(Factory.string)
       assert_equal 'Y',   MuchBoolean.Y_N(true)
       assert_equal 'N',   MuchBoolean.Y_N(false)
+      assert_equal nil,   MuchBoolean.Y_N(nil)
+      assert_equal 'Y',   MuchBoolean.Y_N(Factory.string)
 
       assert_true  MuchBoolean.convert(MuchBoolean.yes_no(true))
       assert_false MuchBoolean.convert(MuchBoolean.yes_no(false))
@@ -146,10 +167,10 @@ class MuchBoolean
       assert_true  bool.actual
     end
 
-    should "default its actual value to `false` when given nothing" do
+    should "default its actual value to nil when given nil" do
       bool = MuchBoolean.new
-      assert_nil   bool.given
-      assert_false bool.actual
+      assert_nil bool.given
+      assert_nil bool.actual
     end
 
     should "know if it is equal to another much boolean or not" do


### PR DESCRIPTION
This switches to ignoring nils in both cases which removes the need
to do nil checks on values in cases where nil should be ignored.  In
cases where nil should not be ignored, users can `!!` their values
when deconverting and nils are inherently "falsy" on their own when
converting.

The also switches the deconversion API to consistently handle value
conversions like the convert API does.  Specifically this means
non-nil non-false values get interpreted as "true" and return the
true value.

I also reformatted the deconversion API methods to better show how
their implementations are related.

@jcredding ready for review.  I noticed these shortcomings when trying to put the deconvert API into one of our apps.
